### PR TITLE
Insert into empty readme files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,7 @@ var markupBadgers = {
 };
 
 var addBadge = function(content, fileExt, imageUrl, linkUrl, altText) {
-  assert(content, 'readme content required');
+  assert(typeof content === 'string', 'readme content required');
   assert(imageUrl, 'badge imageUrl required');
   assert(linkUrl, 'badge linkUrl required');
   assert(altText, 'badge altText required');

--- a/test/examples/empty-after.md
+++ b/test/examples/empty-after.md
@@ -1,0 +1,3 @@
+
+
+[![Join the chat at https://gitter.im/myorg/myrepo](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/myorg/myrepo?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/test/index.js
+++ b/test/index.js
@@ -94,8 +94,8 @@ describe('readme-badger', function() {
   });
 
   it('inserts into empty files', function () {
-    var before = ''
-    var after = '\n\n[![Join the chat at https://gitter.im/myorg/myrepo](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/myorg/myrepo?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)'
+    var before =  fs.readFileSync(__dirname + '/examples/empty-before.md', { encoding: 'utf8' });
+    var after = fs.readFileSync(__dirname + '/examples/empty-after.md', { encoding: 'utf8' });
     var result = badger.addBadge(before, 'md', imageUrl, linkUrl, altText);
     assert.equal(result, after)
   })

--- a/test/index.js
+++ b/test/index.js
@@ -92,4 +92,11 @@ describe('readme-badger', function() {
 
     assert.equal(result, after);
   });
+
+  it('inserts into empty files', function () {
+    var before = ''
+    var after = '\n\n[![Join the chat at https://gitter.im/myorg/myrepo](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/myorg/myrepo?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)'
+    var result = badger.addBadge(before, 'md', imageUrl, linkUrl, altText);
+    assert.equal(result, after)
+  })
 });


### PR DESCRIPTION
It would be nice if the readme-badger would allow empty files as well. All this needs is the assertion to be modified.